### PR TITLE
Bugfix for city/state inputs

### DIFF
--- a/frontend/JavaScript/Question2.js
+++ b/frontend/JavaScript/Question2.js
@@ -1,7 +1,7 @@
 ﻿function Question2(id) {
 
-    answers.state = document.getElementById("state").innerText;
-    answers.city = document.getElementById("city").innerText;
+    answers.state = document.getElementById("state").value;
+    answers.city = document.getElementById("city").value;
 
     var contentHolder = document.getElementById("Question");
 

--- a/frontend/js/question2.js
+++ b/frontend/js/question2.js
@@ -1,7 +1,7 @@
 function question2(){
     //save previous question data to object
-    choices.state = document.getElementById('txtState').innerText;
-    choices.city = document.getElementById('txtCity').innerText;
+    choices.state = document.getElementById('txtState').value;
+    choices.city = document.getElementById('txtCity').value;
 
     var contentHolder = document.getElementById("contentArea");
     var content = `


### PR DESCRIPTION
- Previously, the `.innerHTML` property was being used to access the user input, but this wasn't working.
- Using `.value` is the correct way to access the textboxes' text values.